### PR TITLE
Allow scaling and centering the image in user code

### DIFF
--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -2,7 +2,7 @@ use iced::alignment::Horizontal;
 use iced::widget::{button, column, container, horizontal_rule, slider};
 use iced::{Color, Element, Point, Task, mouse};
 
-use iced_texture_canvas::{Bitmap, bitmap, center_image, scale_image, texture_canvas};
+use iced_texture_canvas::{Bitmap, center_image, scale_image, texture_canvas};
 
 fn main() -> iced::Result {
     iced::application(BasicPaint::default, BasicPaint::update, BasicPaint::view)
@@ -63,9 +63,9 @@ impl BasicPaint {
                 }
             }
             Message::Move(point) => {
-                self.pending.update(point);
-
                 if self.drawing {
+                    self.pending.update(point);
+
                     if let Pending::Line(p1, p2) = self.pending {
                         draw_line(
                             &mut self.bitmap,
@@ -110,8 +110,8 @@ impl BasicPaint {
         column![
             container(
                 texture_canvas(&self.bitmap)
-                    .mouse_interaction(mouse::Interaction::Crosshair)
                     .id("canvas")
+                    .mouse_interaction(mouse::Interaction::Crosshair)
                     .on_move(Message::Move)
                     .on_press(Message::StartDraw)
                     .on_release(Message::EndDraw)
@@ -143,14 +143,7 @@ fn load_image() -> Bitmap {
     let image = image::DynamicImage::from_decoder(png_decoder).expect("valid png image");
 
     // create a new bitmap
-    let mut bitmap = bitmap(image.width(), image.height());
-
-    // update bitmap with the image data
-    let rgba = image.to_rgba8().into_raw();
-
-    bitmap.update(&rgba);
-
-    bitmap
+    Bitmap::new_init(image.width(), image.height(), &image.to_rgba8().into_raw())
 }
 
 enum Pending {

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -39,7 +39,7 @@ impl Default for BasicPaint {
         Self {
             bitmap: load_image(),
             color: WHITE,
-            size: 5,
+            size: 2,
             drawing: false,
             pending: Pending::None,
             scale: 1.0,

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -57,9 +57,8 @@ impl BasicPaint {
             Message::White => self.color = WHITE,
             Message::Black => self.color = BLACK,
             Message::StartDraw(point, button) => {
-                self.pending.update(point);
-
                 if button == mouse::Button::Left {
+                    self.pending.update(point);
                     self.drawing = true
                 }
             }
@@ -82,20 +81,19 @@ impl BasicPaint {
                 }
             }
             Message::EndDraw(last_point, button) => {
-                let was_drawing = self.drawing;
-
                 if button == mouse::Button::Left {
-                    self.drawing = false
-                }
+                    let was_drawing = self.drawing;
+                    self.drawing = false;
 
-                if was_drawing {
-                    put_pixel(
-                        &mut self.bitmap,
-                        last_point.x.floor() as i32,
-                        last_point.y.floor() as i32,
-                        self.color,
-                        self.size,
-                    );
+                    if was_drawing {
+                        put_pixel(
+                            &mut self.bitmap,
+                            last_point.x.floor() as i32,
+                            last_point.y.floor() as i32,
+                            self.color,
+                            self.size,
+                        );
+                    }
                 }
             }
             Message::CenterImage => return center_image("canvas"),

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -1,4 +1,4 @@
-//! Concrete implementation of the [`SurfaceHandler`] (and Surface) in the form of a [`Bitmap`]
+//! Concrete implementation of the [`SurfaceHandler`] (and [`Surface`](crate::Surface)) in the form of a [`Bitmap`]
 use crate::widget::surface::SurfaceHandler;
 
 use std::num::NonZeroU32;

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -19,8 +19,8 @@ pub fn bitmap(width: u32, height: u32) -> Bitmap {
 /// Image data stored on the CPU that can be displayed by a [`TextureCanvas`](crate::TextureCanvas).
 ///
 /// A [`Bitmap`] can be freely edited and resized.
-/// 
-/// **Note**: 
+///
+/// **Note**:
 /// While it contains an [`Arc`], cloning this type will create a new allocation.
 pub struct Bitmap(pub(crate) Arc<SurfaceInner>);
 
@@ -29,7 +29,7 @@ impl Bitmap {
     ///
     /// # Panics
     ///
-    /// Panics if either the width or height is zero.
+    /// Panics if either the `width` or `height` is zero.
     pub fn new(width: u32, height: u32) -> Self {
         let buffer = vec![0; width as usize * height as usize];
 
@@ -45,7 +45,9 @@ impl Bitmap {
     ///
     /// # Panics
     ///
-    /// Panics if the `width` * `height` * `4` doesn't match the length of the data.
+    /// Panics if the `width * height * 4` doesn't match the length of the data.
+    ///
+    /// panics if either the `width` or `height` is zero.
     pub fn new_init(width: u32, height: u32, data: &[u8]) -> Self {
         assert_eq!(
             width as usize * height as usize * 4,
@@ -62,7 +64,7 @@ impl Bitmap {
     ///
     /// # Panics
     ///
-    /// Panics if either the width or height is zero.
+    /// Panics if either the `width` or `height` is zero.
     pub fn resize(&mut self, width: u32, height: u32) {
         if width == self.width() && height == self.height() {
             return;
@@ -111,6 +113,10 @@ impl Bitmap {
     }
 
     /// Update the image buffer with the provided data.
+    /// 
+    /// # Panics
+    /// 
+    /// Panics if the length of the data doesn't match the length of the contained `RGBA` bytes.
     pub fn update(&mut self, data: &[u8]) {
         self.raw_mut().copy_from_slice(data);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@ pub mod bitmap;
 pub mod widget;
 
 pub use bitmap::{Bitmap, bitmap};
-pub use widget::surface::{Surface, SurfaceHandler};
-pub use widget::{TextureCanvas, texture_canvas};
-
 pub use widget::style::{self, Catalog, Status, Style, StyleFn};
+pub use widget::surface::{Surface, SurfaceHandler};
+pub use widget::{TextureCanvas, center_image, scale_image, texture_canvas};
+
+pub use iced_core::widget::Id;

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -500,6 +500,9 @@ where
 
                 Event::Mouse(mouse::Event::WheelScrolled { delta }) => match delta {
                     mouse::ScrollDelta::Lines { y, .. } => {
+                        if state.grabbing {
+                            return;
+                        }
                         // align the canvas to the mouse position when scaling.
                         // first we calculate what % the cursor is from the canvas on both axes.
                         // 0% = far left, or top

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,22 +1,29 @@
+pub mod operation;
 mod primitive;
 pub mod style;
 pub mod surface;
 
 use primitive::Primitive;
 use style::{Catalog, Status, Style, StyleFn};
-
 use surface::{Surface, SurfaceHandler};
-
-use glam::Vec2;
 
 use iced_core::{
     Border, Element, Event, Layout, Length, Point, Rectangle, Shadow, Shell, Size, Widget, layout,
-    mouse, renderer, widget, window,
+    mouse, renderer,
+    widget::{self, Id},
+    window,
+};
+use iced_widget::runtime::{
+    Action,
+    task::{self, Task},
 };
 
 const MIN_SCALE: f32 = 1.0; //0.05;
 const MAX_SCALE: f32 = 1600.0;
 
+/// Create a new [`TextureCanvas`] with the given [`SurfaceHandler`].
+///
+/// You can use the provided [`Bitmap`](crate::Bitmap).
 pub fn texture_canvas<'a, Message, Theme, Handler>(
     buffer: &'a Handler,
 ) -> TextureCanvas<'a, Message, Theme, Handler>
@@ -28,6 +35,20 @@ where
     TextureCanvas::new(buffer)
 }
 
+/// A [`Task`] that centers the image in the [`TextureCanvas`] with the given [`Id`].
+///
+/// This requires that you also [`set the id`](TextureCanvas::id) of the [`TextureCanvas`].
+pub fn center_image<Message>(id: impl Into<Id>) -> Task<Message> {
+    task::effect(Action::widget(operation::center_image_raw(id.into())))
+}
+
+/// A [`Task`] that scales the image in the [`TextureCanvas`] with the given [`Id`].
+///
+/// This requires that you also [`set the id`](TextureCanvas::id) of the [`TextureCanvas`].
+pub fn scale_image<Message>(id: impl Into<Id>, scale: f32) -> Task<Message> {
+    task::effect(Action::widget(operation::scale_image_raw(id.into(), scale)))
+}
+
 pub struct TextureCanvas<'a, Message, Theme, Handler>
 where
     Theme: Catalog,
@@ -37,6 +58,7 @@ where
     height: Length,
 
     class: Theme::Class<'a>,
+    id: Option<Id>,
 
     on_grab: Option<Box<dyn Fn() -> Message + 'a>>,
     on_zoom: Option<Box<dyn Fn(f32) -> Message + 'a>>,
@@ -54,6 +76,9 @@ where
     Theme: style::Catalog,
     Handler: SurfaceHandler,
 {
+    /// Create a new [`TextureCanvas`] with the given [`SurfaceHandler`].
+    ///
+    /// You can use the provided [`Bitmap`](crate::Bitmap).
     pub fn new(buffer: &'a Handler) -> Self {
         Self {
             buffer,
@@ -68,6 +93,7 @@ where
             on_exit: None,
             interaction: None,
             class: Theme::default(),
+            id: None,
         }
     }
 
@@ -106,7 +132,7 @@ where
         self
     }
 
-    /// Set the message that will be produced when the image is zoomed.
+    /// Set the message to emit when the image has been zoomed in/out.
     pub fn on_zoom(mut self, on_zoom: impl Fn(f32) -> Message + 'a) -> Self {
         self.on_zoom = Some(Box::new(on_zoom));
         self
@@ -194,6 +220,15 @@ where
         self.interaction = Some(mouse_interaction);
         self
     }
+
+    /// Set the [`Id`] of the [`TextureCanvas`].
+    ///
+    /// You will need to do this if you need to manually
+    /// [`scale`](scale_image)/[`center`](center_image) the contained image.
+    pub fn id(mut self, id: impl Into<Id>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
 }
 
 impl<'a, Message, Theme, Renderer, Handler> Widget<Message, Theme, Renderer>
@@ -241,7 +276,7 @@ where
         let bounds = layout.bounds();
         let state = tree.state.downcast_ref::<State>();
 
-        let Vec2 { x, y } = state.canvas_offset;
+        let glam::Vec2 { x, y } = state.canvas_offset;
         let scale = state.scale;
 
         let texture_width = self.buffer.width() as f32 * scale;
@@ -338,10 +373,37 @@ where
 
         if state.should_center {
             state.should_center = false;
-            state.canvas_offset = Vec2::new(
-                bounds.center_x() - image_width / 2.,
-                bounds.center_y() - image_height / 2.,
+            state.canvas_offset = glam::Vec2::new(
+                bounds.center_x() - (image_width * state.scale) / 2.,
+                bounds.center_y() - (image_height * state.scale) / 2.,
             );
+        }
+
+        // TODO: refactor
+        if let Some(new_scale) = state.suggested_scale.take() {
+            let center = bounds.center();
+
+            let point = to_canvas_coords(bounds, center, state.canvas_offset, state.scale);
+
+            let x_percent = point.x / image_width;
+            let y_percent = point.y / image_height;
+
+            state.scale = (new_scale).clamp(MIN_SCALE, MAX_SCALE);
+
+            // recalculate the bounds of the canvas
+            let new_canvas_width = image_width * state.scale;
+            let new_canvas_height = image_height * state.scale;
+
+            // move the canvas offset to satisfy the percentages.
+            state.canvas_offset = glam::Vec2::new(
+                (center.x - new_canvas_width * x_percent) - bounds.x,
+                (center.y - new_canvas_height * y_percent) - bounds.y,
+            );
+
+            shell.request_redraw();
+            if let Some(on_zoom) = &self.on_zoom {
+                shell.publish(on_zoom(state.scale));
+            };
         }
 
         if !cursor.is_over(bounds) {
@@ -380,19 +442,6 @@ where
                 }
             }
 
-            fn to_canvas_coords(
-                bounds: Rectangle,
-                mouse: Point,
-                offset: Vec2,
-                scale: f32,
-            ) -> Point {
-                let mouse = glam::vec2(mouse.x, mouse.y);
-                let bounds_offset = glam::vec2(bounds.x, bounds.y) / scale;
-                let Vec2 { x, y } = (mouse - offset) / scale - bounds_offset;
-
-                Point { x, y }
-            }
-
             match event {
                 Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Middle)) => {
                     state.grabbing = true;
@@ -419,7 +468,7 @@ where
                     let mouse_pos = *position;
 
                     if state.grabbing {
-                        let mouse_pos = Vec2::new(mouse_pos.x, mouse_pos.y);
+                        let mouse_pos = glam::Vec2::new(mouse_pos.x, mouse_pos.y);
 
                         if let Some(pos) = state.canvas_grab {
                             state.canvas_offset = mouse_pos - pos
@@ -450,7 +499,7 @@ where
                 }
 
                 Event::Mouse(mouse::Event::WheelScrolled { delta }) => match delta {
-                    mouse::ScrollDelta::Lines { x, y } => {
+                    mouse::ScrollDelta::Lines { y, .. } => {
                         // align the canvas to the mouse position when scaling.
                         // first we calculate what % the cursor is from the canvas on both axes.
                         // 0% = far left, or top
@@ -479,12 +528,16 @@ where
                         let new_canvas_height = image_height * state.scale;
 
                         // move the canvas offset to satisfy the percentages.
-                        state.canvas_offset = Vec2::new(
+                        state.canvas_offset = glam::Vec2::new(
                             (mouse_pos.x - new_canvas_width * x_percent) - bounds.x,
                             (mouse_pos.y - new_canvas_height * y_percent) - bounds.y,
                         );
 
                         shell.request_redraw();
+
+                        if let Some(on_zoom) = &self.on_zoom {
+                            shell.publish(on_zoom(state.scale));
+                        };
                     }
 
                     mouse::ScrollDelta::Pixels { y, .. } => {
@@ -499,6 +552,17 @@ where
         } else {
             state.reset();
         };
+    }
+
+    fn operate(
+        &self,
+        tree: &mut widget::Tree,
+        layout: Layout<'_>,
+        _renderer: &Renderer,
+        operation: &mut dyn widget::Operation,
+    ) {
+        let state: &mut State = tree.state.downcast_mut();
+        operation.custom(self.id.as_ref(), layout.bounds(), state);
     }
 }
 
@@ -515,17 +579,25 @@ where
     }
 }
 
-/// TODO: move canvas offset and zoom to user state
-pub struct State {
+fn to_canvas_coords(bounds: Rectangle, mouse: Point, offset: glam::Vec2, scale: f32) -> Point {
+    let mouse = glam::vec2(mouse.x, mouse.y);
+    let bounds_offset = glam::vec2(bounds.x, bounds.y) / scale;
+    let glam::Vec2 { x, y } = (mouse - offset) / scale - bounds_offset;
+
+    Point { x, y }
+}
+
+pub(crate) struct State {
     canvas_grab: Option<glam::Vec2>,
     grabbing: bool,
     canvas_offset: glam::Vec2,
-    scale: f32,
+    pub scale: f32,
     is_hovered: bool,
     /// Used to force the shader pipeline to update the texture
     /// if there's a mismatch.
     generation: u64,
-    should_center: bool,
+    pub should_center: bool,
+    pub suggested_scale: Option<f32>,
 }
 
 impl Default for State {
@@ -538,6 +610,7 @@ impl Default for State {
             is_hovered: Default::default(),
             generation: new_generation(),
             should_center: true,
+            suggested_scale: None,
         }
     }
 }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -18,8 +18,8 @@ use iced_widget::runtime::{
     task::{self, Task},
 };
 
-const MIN_SCALE: f32 = 1.0; //0.05;
-const MAX_SCALE: f32 = 1600.0;
+const MIN_SCALE: f32 = 1.0; //0.05; // TODO
+const MAX_SCALE: f32 = 64.0; // 6,400%
 
 /// Create a new [`TextureCanvas`] with the given [`SurfaceHandler`].
 ///

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -369,7 +369,7 @@ where
         let state = tree.state.downcast_mut::<State>();
 
         let image_width = self.buffer.width() as f32;
-        let image_height = self.buffer.width() as f32;
+        let image_height = self.buffer.height() as f32;
 
         if state.should_center {
             state.should_center = false;

--- a/src/widget/operation.rs
+++ b/src/widget/operation.rs
@@ -1,0 +1,71 @@
+use super::State;
+
+use iced_core::widget::{self, Id, Operation};
+
+/// Create an [`Operation`] that will center the image given an [`Id`].
+pub fn center_image_raw(id: Id) -> impl Operation + 'static {
+    CenterImage { id: id.into() }
+}
+
+struct CenterImage {
+    id: Id,
+}
+
+impl<T> Operation<T> for CenterImage {
+    fn container(
+        &mut self,
+        _id: Option<&Id>,
+        _bounds: iced_core::Rectangle,
+        operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
+    ) {
+        operate_on_children(self);
+    }
+
+    fn custom(
+        &mut self,
+        id: Option<&Id>,
+        _bounds: iced_core::Rectangle,
+        state: &mut dyn std::any::Any,
+    ) {
+        if id == Some(&self.id) {
+            let state: &mut State = state.downcast_mut().unwrap();
+            state.should_center = true;
+        }
+    }
+}
+
+/// Create an [`Operation`] that will scale the image given an [`Id`].
+pub fn scale_image_raw(id: widget::Id, scale: f32) -> impl Operation + 'static {
+    ScaleImage {
+        id: id.into(),
+        scale,
+    }
+}
+
+struct ScaleImage {
+    id: widget::Id,
+    scale: f32,
+}
+
+impl<T> Operation<T> for ScaleImage {
+    fn container(
+        &mut self,
+        _id: Option<&widget::Id>,
+        _bounds: iced_core::Rectangle,
+        operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
+    ) {
+        operate_on_children(self);
+    }
+
+    fn custom(
+        &mut self,
+        id: Option<&widget::Id>,
+        _bounds: iced_core::Rectangle,
+        state: &mut dyn std::any::Any,
+    ) {
+        if id == Some(&self.id) {
+            let state: &mut State = state.downcast_mut().unwrap();
+            state.suggested_scale = Some(self.scale);
+        }
+    }
+}


### PR DESCRIPTION
Currently the only way to interact with the image is through the cursor. Now it's possible to center and scale the displayed image using widget operations - `center_image` and `scale_image` respectively.

The paint program example has also been updated to demonstrate this.